### PR TITLE
fix: Update CI to support Go 1.19+ and fix pkger installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.19.x, 1.20.x]
 
     runs-on: ${{ matrix.os }}
     steps:
 
     - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
       id: go
@@ -28,10 +28,13 @@ jobs:
     - name: Get Go dependencies
       run: go get -v -t -d ./...
 
-    - name: Build
+    - name: Install pkger
       run: |
-        export PATH=~/go/bin:$PATH
-        make build
+        go install -v github.com/markbates/pkger/cmd/pkger@v0.17.1
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+    - name: Build
+      run: make build
 
     - name: Unit tests
       run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GO=GO111MODULE=on go
 GOBUILD=$(GO) build
+PKGER_BIN := $(shell command -v pkger 2> /dev/null)
 
 all: build
 
@@ -7,12 +8,16 @@ build: bundled/pkged.go
 	$(GOBUILD) ./cli/gocomply_fedramp
 
 bundled/pkged.go: pkger README.md
-	pkger -o bundled
+ifdef PKGER_BIN
+	$(PKGER_BIN) -o bundled
+else
+	GO111MODULE=on go run -mod=mod github.com/markbates/pkger/cmd/pkger -o bundled
+endif
 
 .PHONY: pkger vendor
 pkger:
 ifeq ("$(wildcard $(GOPATH)/bin/pkger)","")
-	go get -u -v github.com/markbates/pkger/cmd/pkger
+	go install -v github.com/markbates/pkger/cmd/pkger@v0.17.1
 endif
 
 ci-update-bundled-deps: ci-update-fedramp-templates ci-update-fedramp-catalogs


### PR DESCRIPTION
- Update Go versions from 1.13.x/1.14.x to 1.19.x/1.20.x
- Fix pkger installation to use 'go install' for Go 1.17+
- Add conditional pkger execution in Makefile